### PR TITLE
OIDC for web

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,7 +4,7 @@ ARG BUILDARCH=amd64
 
 # Stage 1: Builder Stage
 # FROM golang:${GO_VERSION}-alpine AS builder
-FROM crazymax/xgo:${GO_VERSION} AS builder
+FROM crazymax/xgo:${GO_VERSION} AS builder-backend
 
 # Set up working directory
 WORKDIR /app
@@ -27,7 +27,7 @@ RUN CGO_ENABLED=1 GOOS=linux go build -a \
     -installsuffix cgo -o release/apimain cmd/apimain.go
 
 # Stage 2: Frontend Build Stage (builder2)
-FROM node:18-alpine AS builder2
+FROM node:18-alpine AS builder-admin-frontend
 
 # Set working directory
 WORKDIR /frontend
@@ -50,12 +50,12 @@ WORKDIR /app
 RUN apk add --no-cache tzdata file
 
 # Copy the built application and resources from the builder stage
-COPY --from=builder /app/release /app/
-COPY --from=builder /app/conf /app/conf/
-COPY --from=builder /app/resources /app/resources/
-COPY --from=builder /app/docs /app/docs/
+COPY --from=builder-backend /app/release /app/
+COPY --from=builder-backend /app/conf /app/conf/
+COPY --from=builder-backend /app/resources /app/resources/
+COPY --from=builder-backend /app/docs /app/docs/
 # Copy frontend build from builder2 stage
-COPY --from=builder2 /frontend/dist/ /app/resources/admin/
+COPY --from=builder-admin-frontend /frontend/dist/ /app/resources/admin/
 
 # Ensure the binary is correctly built and linked
 RUN file /app/apimain && \

--- a/http/router/admin.go
+++ b/http/router/admin.go
@@ -33,7 +33,6 @@ func Init(g *gin.Engine) {
 	rs := &admin.Rustdesk{}
 	adg.GET("/server-config", rs.ServerConfig)
 	adg.GET("/app-config", rs.AppConfig)
-
 	//访问静态文件
 	//g.StaticFS("/upload", http.Dir(global.Config.Gin.ResourcesPath+"/upload"))
 }
@@ -41,6 +40,9 @@ func LoginBind(rg *gin.RouterGroup) {
 	cont := &admin.Login{}
 	rg.POST("/login", cont.Login)
 	rg.POST("/logout", cont.Logout)
+	rg.GET("/login-options", cont.LoginOptions)
+	rg.POST("/oidc/auth", cont.OidcAuth)
+	rg.GET("/oidc/auth-query", cont.OidcAuthQuery)
 }
 
 func UserBind(rg *gin.RouterGroup) {


### PR DESCRIPTION
前端修改在：lejianwen/rustdesk-api-web/pull/3

## 说明
尽量遵从当前认证逻辑，网页版的token和pc端的oauth认证流程，我不确定这样的妥协是不是一个好的注意。

### 认证流程
1. 前端通过端点 `/api/admin/login-options` 获取与PC端一样的返回（也许我应该修改一下返回格式），然后进行解析并在登陆页面显示支持的Oauth方式
2. 点击Oauth认证方式，向后端 `/api/admin/oidc/auth` 发出POST，data内容跟PC端相同，返回的数据是相同的；但是格式不同，此处返回标准格式`response`. 
3. 前端接收到返回的数据`{code, url}`, 前端将code存在localStorage中（60秒过期），然后重定向之`url`之IdP
4. IdP认证之后会将token发送至`/api/oidc/callback`，此时后端根据code来判断，这次认证的类型是`webadmin`，所以在完成认证之后会重定向至`ApiServer + "/_admin/#/"`，也就是前端首页
5. 前端首页进入的时候，会判断code是否存在，如果存在则向`/api/admin/oidc/auth-query`进行查询用户信息，然后删除code（code只能使用一次）
6. 完成认证
