### PR TITLE
Reset empty password

### DIFF
--- a/http/controller/admin/user.go
+++ b/http/controller/admin/user.go
@@ -247,10 +247,14 @@ func (ct *User) ChangeCurPwd(c *gin.Context) {
 		return
 	}
 	u := service.AllService.UserService.CurUser(c)
-	oldPwd := service.AllService.UserService.EncryptPassword(f.OldPassword)
-	if u.Password != oldPwd {
-		response.Fail(c, 101, response.TranslateMsg(c, "OldPasswordError"))
-		return
+	// If the password is not empty, the old password is verified
+	// otherwise, the old password is not verified
+	if !service.AllService.UserService.IsPasswordEmptyByUser(u) {
+		oldPwd := service.AllService.UserService.EncryptPassword(f.OldPassword)
+		if u.Password != oldPwd {
+			response.Fail(c, 101, response.TranslateMsg(c, "OldPasswordError"))
+			return
+		}
 	}
 	err := service.AllService.UserService.UpdatePassword(u, f.NewPassword)
 	if err != nil {

--- a/service/user.go
+++ b/service/user.go
@@ -304,3 +304,27 @@ func (us *UserService) FindLatestUserIdFromLoginLogByUuid(uuid string) uint {
 	global.DB.Where("uuid = ?", uuid).Order("id desc").First(llog)
 	return llog.UserId
 }
+
+// IsPasswordEmptyById 根据用户id判断密码是否为空，主要用于第三方登录的自动注册
+func (us *UserService) IsPasswordEmptyById(id uint) bool {
+	u := &model.User{}
+	if global.DB.Where("id = ?", id).First(u).Error != nil {
+		return false
+	}
+	return u.Password == ""
+}
+
+// IsPasswordEmptyByUsername 根据用户id判断密码是否为空，主要用于第三方登录的自动注册
+func (us *UserService) IsPasswordEmptyByUsername(username string) bool {
+	u := &model.User{}
+	if global.DB.Where("username = ?", username).First(u).Error != nil {
+		return false
+	}
+	return u.Password == ""
+}
+
+// IsPasswordEmptyByUser 判断密码是否为空，主要用于第三方登录的自动注册
+func (us *UserService) IsPasswordEmptyByUser(u *model.User) bool {
+	return us.IsPasswordEmptyById(u.Id)
+}
+


### PR DESCRIPTION
对于Oauth自动注册的用户来说，用户不知道密码。如果想使用账号密码登陆需要联系管理员。
此PR允许Oauth自动注册的用户，第一次（仅）可以随便输入`旧密码`来重置密码。