### PR TITLE
re-construct oauth

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -42,8 +42,11 @@ RUN if [ "$COUNTRY" = "CN" ] ; then \
     fi && \
     apk update && apk add --no-cache git
 
+ARG FREONTEND_GIT_REPO=https://github.com/lejianwen/rustdesk-api-web.git
+ARG FRONTEND_GIT_BRANCH=master
 # Clone the frontend repository
-RUN git clone https://github.com/lejianwen/rustdesk-api-web .
+
+RUN git clone -b $FRONTEND_GIT_BRANCH $FREONTEND_GIT_REPO .
 
 # Install required tools without caching index to minimize image size
 RUN if [ "$COUNTRY" = "CN" ] ; then \

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -5,6 +5,8 @@ services:
       dockerfile: Dockerfile.dev
       args:
         COUNTRY: CN
+        FREONTEND_GIT_REPO: https://github.com/lejianwen/rustdesk-api-web.git
+        FRONTEND_GIT_BRANCH: master
     # image: lejianwen/rustdesk-api
     container_name: rustdesk-api
     environment:

--- a/http/controller/admin/login.go
+++ b/http/controller/admin/login.go
@@ -11,7 +11,6 @@ import (
 	"Gwen/service"
 	"fmt"
 	"github.com/gin-gonic/gin"
-	"gorm.io/gorm"
 )
 
 type Login struct {
@@ -91,13 +90,7 @@ func (ct *Login) Logout(c *gin.Context) {
 // @Failure 500 {object} response.ErrorResponse
 // @Router /admin/login-options [post]
 func (ct *Login) LoginOptions(c *gin.Context) {
-	res := service.AllService.OauthService.List(1, 100, func(tx *gorm.DB) {
-		tx.Select("op").Order("id")
-	})
-	var ops []string
-	for _, v := range res.Oauths {
-		ops = append(ops, v.Op)
-	}
+	ops := service.AllService.OauthService.GetOauthProviders()
 	response.Success(c, gin.H{
 		"ops":      ops,
 		"register": global.Config.App.Register,

--- a/http/controller/admin/login.go
+++ b/http/controller/admin/login.go
@@ -63,6 +63,8 @@ func (ct *Login) Login(c *gin.Context) {
 	response.Success(c, &adResp.LoginPayload{
 		Token:      ut.Token,
 		Username:   u.Username,
+		Email:      u.Email,
+		Avatar:     u.Avatar,
 		RouteNames: service.AllService.UserService.RouteNames(u),
 		Nickname:   u.Nickname,
 	})

--- a/http/controller/admin/login.go
+++ b/http/controller/admin/login.go
@@ -60,14 +60,7 @@ func (ct *Login) Login(c *gin.Context) {
 		Platform: f.Platform,
 	})
 
-	response.Success(c, &adResp.LoginPayload{
-		Token:      ut.Token,
-		Username:   u.Username,
-		Email:      u.Email,
-		Avatar:     u.Avatar,
-		RouteNames: service.AllService.UserService.RouteNames(u),
-		Nickname:   u.Nickname,
-	})
+	responseLoginSuccess(c, u, ut.Token)
 }
 
 // Logout 登出
@@ -165,12 +158,14 @@ func (ct *Login) OidcAuthQuery(c *gin.Context) {
 	if ut == nil {
 		return
 	}
-	//fmt.Println("u:", u)
-	//fmt.Println("ut:", ut)
-	response.Success(c, &adResp.LoginPayload{
-		Token:      ut.Token,
-		Username:   u.Username,
-		RouteNames: service.AllService.UserService.RouteNames(u),
-		Nickname:   u.Nickname,
-	})
+	responseLoginSuccess(c, u, ut.Token)
+}
+
+
+func responseLoginSuccess(c *gin.Context, u *model.User, token string) {
+	lp := &adResp.LoginPayload{}
+	lp.FromUser(u)
+	lp.Token = token
+	lp.RouteNames = service.AllService.UserService.RouteNames(u)
+	response.Success(c, lp)
 }

--- a/http/controller/admin/user.go
+++ b/http/controller/admin/user.go
@@ -391,7 +391,7 @@ func (ct *User) Register(c *gin.Context) {
 		response.Fail(c, 101, errList[0])
 		return
 	}
-	u := service.AllService.UserService.Register(f.Username, f.Password)
+	u := service.AllService.UserService.Register(f.Username, f.Email, f.Password)
 	if u == nil || u.Id == 0 {
 		response.Fail(c, 101, response.TranslateMsg(c, "OperationFailed"))
 		return

--- a/http/controller/admin/user.go
+++ b/http/controller/admin/user.go
@@ -286,10 +286,10 @@ func (ct *User) MyOauth(c *gin.Context) {
 	var res []*adResp.UserOauthItem
 	for _, oa := range oal.Oauths {
 		item := &adResp.UserOauthItem{
-			ThirdType: oa.Op,
+			Op: oa.Op,
 		}
 		for _, ut := range uts {
-			if ut.ThirdType == oa.Op {
+			if ut.Op == oa.Op {
 				item.Status = 1
 				break
 			}

--- a/http/controller/admin/user.go
+++ b/http/controller/admin/user.go
@@ -217,12 +217,7 @@ func (ct *User) Current(c *gin.Context) {
 	u := service.AllService.UserService.CurUser(c)
 	token, _ := c.Get("token")
 	t := token.(string)
-	response.Success(c, &adResp.LoginPayload{
-		Token:      t,
-		Username:   u.Username,
-		RouteNames: service.AllService.UserService.RouteNames(u),
-		Nickname:   u.Nickname,
-	})
+	responseLoginSuccess(c, u, t)
 }
 
 // ChangeCurPwd 修改当前用户密码
@@ -404,11 +399,5 @@ func (ct *User) Register(c *gin.Context) {
 		Ip:     c.ClientIP(),
 		Type:   model.LoginLogTypeAccount,
 	})
-	response.Success(c, &adResp.LoginPayload{
-		Token:      ut.Token,
-		Username:   u.Username,
-		Email:	  	u.Email,
-		RouteNames: service.AllService.UserService.RouteNames(u),
-		Nickname:   u.Nickname,
-	})
+	responseLoginSuccess(c, u, ut.Token)
 }

--- a/http/controller/admin/user.go
+++ b/http/controller/admin/user.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 	"strconv"
+	"time"
 )
 
 type User struct {
@@ -296,6 +297,51 @@ func (ct *User) MyOauth(c *gin.Context) {
 		}
 		res = append(res, item)
 	}
+	response.Success(c, res)
+}
+
+// List 列表
+// @Tags 设备
+// @Summary 设备列表
+// @Description 设备列表
+// @Accept  json
+// @Produce  json
+// @Param page query int false "页码"
+// @Param page_size query int false "页大小"
+// @Param time_ago query int false "时间"
+// @Param id query string false "ID"
+// @Param hostname query string false "主机名"
+// @Param uuids query string false "uuids 用逗号分隔"
+// @Success 200 {object} response.Response{data=model.PeerList}
+// @Failure 500 {object} response.Response
+// @Router /admin/user/myPeer [get]
+// @Security token
+func (ct *User) MyPeer(c *gin.Context) {
+	query := &admin.PeerQuery{}
+	if err := c.ShouldBindQuery(query); err != nil {
+		response.Fail(c, 101, response.TranslateMsg(c, "ParamsError")+err.Error())
+		return
+	}
+	u := service.AllService.UserService.CurUser(c)
+	res := service.AllService.PeerService.ListFilterByUserId(query.Page, query.PageSize, func(tx *gorm.DB) {
+		if query.TimeAgo > 0 {
+			lt := time.Now().Unix() - int64(query.TimeAgo)
+			tx.Where("last_online_time < ?", lt)
+		}
+		if query.TimeAgo < 0 {
+			lt := time.Now().Unix() + int64(query.TimeAgo)
+			tx.Where("last_online_time > ?", lt)
+		}
+		if query.Id != "" {
+			tx.Where("id like ?", "%"+query.Id+"%")
+		}
+		if query.Hostname != "" {
+			tx.Where("hostname like ?", "%"+query.Hostname+"%")
+		}
+		if query.Uuids != "" {
+			tx.Where("uuid in (?)", query.Uuids)
+		}
+	}, u.Id)
 	response.Success(c, res)
 }
 

--- a/http/controller/admin/user.go
+++ b/http/controller/admin/user.go
@@ -361,6 +361,7 @@ func (ct *User) Register(c *gin.Context) {
 	response.Success(c, &adResp.LoginPayload{
 		Token:      ut.Token,
 		Username:   u.Username,
+		Email:	  	u.Email,
 		RouteNames: service.AllService.UserService.RouteNames(u),
 		Nickname:   u.Nickname,
 	})

--- a/http/controller/api/login.go
+++ b/http/controller/api/login.go
@@ -60,7 +60,7 @@ func (l *Login) Login(c *gin.Context) {
 	ut := service.AllService.UserService.Login(u, &model.LoginLog{
 		UserId:   u.Id,
 		Client:   f.DeviceInfo.Type,
-		DeviceId:       f.Id,
+		DeviceId: f.Id,
 		Uuid:     f.Uuid,
 		Ip:       c.ClientIP(),
 		Type:     model.LoginLogTypeAccount,

--- a/http/controller/api/login.go
+++ b/http/controller/api/login.go
@@ -60,6 +60,7 @@ func (l *Login) Login(c *gin.Context) {
 	ut := service.AllService.UserService.Login(u, &model.LoginLog{
 		UserId:   u.Id,
 		Client:   f.DeviceInfo.Type,
+		DeviceId:       f.Id,
 		Uuid:     f.Uuid,
 		Ip:       c.ClientIP(),
 		Type:     model.LoginLogTypeAccount,

--- a/http/controller/api/login.go
+++ b/http/controller/api/login.go
@@ -83,22 +83,10 @@ func (l *Login) Login(c *gin.Context) {
 // @Failure 500 {object} response.ErrorResponse
 // @Router /login-options [get]
 func (l *Login) LoginOptions(c *gin.Context) {
-	oauthOks := []string{}
-	err, _ := service.AllService.OauthService.GetOauthConfig(model.OauthTypeGithub)
-	if err == nil {
-		oauthOks = append(oauthOks, model.OauthTypeGithub)
-	}
-	err, _ = service.AllService.OauthService.GetOauthConfig(model.OauthTypeGoogle)
-	if err == nil {
-		oauthOks = append(oauthOks, model.OauthTypeGoogle)
-	}
-	err, _ = service.AllService.OauthService.GetOauthConfig(model.OauthTypeOidc)
-	if err == nil {
-		oauthOks = append(oauthOks, model.OauthTypeOidc)
-	}
-	oauthOks = append(oauthOks, model.OauthTypeWebauth)
+	ops := service.AllService.OauthService.GetOauthProviders()
+	ops = append(ops, model.OauthTypeWebauth)
 	var oidcItems []map[string]string
-	for _, v := range oauthOks {
+	for _, v := range ops {
 		oidcItems = append(oidcItems, map[string]string{"name": v})
 	}
 	common, err := json.Marshal(oidcItems)
@@ -108,7 +96,7 @@ func (l *Login) LoginOptions(c *gin.Context) {
 	}
 	var res []string
 	res = append(res, "common-oidc/"+string(common))
-	for _, v := range oauthOks {
+	for _, v := range ops {
 		res = append(res, "oidc/"+v)
 	}
 	c.JSON(http.StatusOK, res)

--- a/http/controller/api/ouath.go
+++ b/http/controller/api/ouath.go
@@ -32,12 +32,6 @@ func (o *Oauth) OidcAuth(c *gin.Context) {
 	}
 
 	oauthService := service.AllService.OauthService
-	err = oauthService.ValidateOauthProvider(f.Op)
-	if err != nil {
-		response.Error(c, response.TranslateMsg(c, err.Error()))
-		return
-	}
-
 	var code string
 	var url string
 	err, code, url = oauthService.BeginAuth(f.Op)

--- a/http/controller/api/ouath.go
+++ b/http/controller/api/ouath.go
@@ -208,9 +208,9 @@ func (o *Oauth) OauthCallback(c *gin.Context) {
 			}
 
 			//自动注册
-			user = service.AllService.UserService.RegisterByOauth(oauthUser, op)
-			if user.Id == 0 {
-				c.String(http.StatusInternalServerError, response.TranslateMsg(c, "OauthRegisterFailed"))
+			err, user = service.AllService.UserService.RegisterByOauth(oauthUser, op)
+			if err != nil {
+				c.String(http.StatusInternalServerError, response.TranslateMsg(c, err.Error()))
 				return
 			}
 		}

--- a/http/controller/api/ouath.go
+++ b/http/controller/api/ouath.go
@@ -9,8 +9,6 @@ import (
 	"Gwen/service"
 	"github.com/gin-gonic/gin"
 	"net/http"
-	"strconv"
-	"strings"
 )
 
 type Oauth struct {
@@ -32,13 +30,17 @@ func (o *Oauth) OidcAuth(c *gin.Context) {
 		response.Error(c, response.TranslateMsg(c, "ParamsError")+err.Error())
 		return
 	}
-	//fmt.Println(f)
-	if f.Op != model.OauthTypeWebauth && f.Op != model.OauthTypeGoogle && f.Op != model.OauthTypeGithub && f.Op != model.OauthTypeOidc {
-		response.Error(c, response.TranslateMsg(c, "ParamsError"))
+
+	oauthService := service.AllService.OauthService
+	err = oauthService.ValidateOauthProvider(f.Op)
+	if err != nil {
+		response.Error(c, response.TranslateMsg(c, err.Error()))
 		return
 	}
 
-	err, code, url := service.AllService.OauthService.BeginAuth(f.Op)
+	var code string
+	var url string
+	err, code, url = oauthService.BeginAuth(f.Op)
 	if err != nil {
 		response.Error(c, response.TranslateMsg(c, err.Error()))
 		return
@@ -149,70 +151,43 @@ func (o *Oauth) OauthCallback(c *gin.Context) {
 		c.String(http.StatusInternalServerError, response.TranslateParamMsg(c, "ParamIsEmpty", "state"))
 		return
 	}
-
 	cacheKey := state
+	oauthService := service.AllService.OauthService
 	//从缓存中获取
-	v := service.AllService.OauthService.GetOauthCache(cacheKey)
-	if v == nil {
+	oauthCache := oauthService.GetOauthCache(cacheKey)
+	if oauthCache == nil {
 		c.String(http.StatusInternalServerError, response.TranslateMsg(c, "OauthExpired"))
 		return
 	}
-
-	ty := v.Op
-	ac := v.Action
-	var u *model.User
-	openid := ""
-	thirdName := ""
-	//fmt.Println("ty ac ", ty, ac)
-
-	if ty == model.OauthTypeGithub {
-		code := c.Query("code")
-		err, userData := service.AllService.OauthService.GithubCallback(code)
-		if err != nil {
-			c.String(http.StatusInternalServerError, response.TranslateMsg(c, "OauthFailed")+response.TranslateMsg(c, err.Error()))
-			return
-		}
-		openid = strconv.Itoa(userData.Id)
-		thirdName = userData.Login
-	} else if ty == model.OauthTypeGoogle {
-		code := c.Query("code")
-		err, userData := service.AllService.OauthService.GoogleCallback(code)
-		if err != nil {
-			c.String(http.StatusInternalServerError, response.TranslateMsg(c, "OauthFailed")+response.TranslateMsg(c, err.Error()))
-			return
-		}
-		openid = userData.Email
-		//将空格替换成_
-		thirdName = strings.Replace(userData.Name, " ", "_", -1)
-	} else if ty == model.OauthTypeOidc {
-		code := c.Query("code")
-		err, userData := service.AllService.OauthService.OidcCallback(code)
-		if err != nil {
-			c.String(http.StatusInternalServerError, response.TranslateMsg(c, "OauthFailed")+response.TranslateMsg(c, err.Error()))
-			return
-		}
-		openid = userData.Sub
-		thirdName = userData.PreferredUsername
-	} else {
-		c.String(http.StatusInternalServerError, response.TranslateMsg(c, "ParamsError"))
+	op := oauthCache.Op
+	action := oauthCache.Action
+	var user *model.User
+	// 获取用户信息
+	code := c.Query("code")
+	err, oauthUser := oauthService.Callback(code, op)
+	if err != nil {
+		c.String(http.StatusInternalServerError, response.TranslateMsg(c, "OauthFailed")+response.TranslateMsg(c, err.Error()))
 		return
 	}
-	if ac == service.OauthActionTypeBind {
+	userId := oauthCache.UserId
+	openid := oauthUser.OpenId
+	if action == service.OauthActionTypeBind {
 
 		//fmt.Println("bind", ty, userData)
-		utr := service.AllService.OauthService.UserThirdInfo(ty, openid)
+		// 检查此openid是否已经绑定过
+		utr := oauthService.UserThirdInfo(op, openid)
 		if utr.UserId > 0 {
 			c.String(http.StatusInternalServerError, response.TranslateMsg(c, "OauthHasBindOtherUser"))
 			return
 		}
 		//绑定
-		u = service.AllService.UserService.InfoById(v.UserId)
-		if u == nil {
+		user = service.AllService.UserService.InfoById(userId)
+		if user == nil {
 			c.String(http.StatusInternalServerError, response.TranslateMsg(c, "ItemNotFound"))
 			return
 		}
 		//绑定
-		err := service.AllService.OauthService.BindOauthUser(ty, openid, thirdName, v.UserId)
+		err := oauthService.BindOauthUser(userId, oauthUser, op)
 		if err != nil {
 			c.String(http.StatusInternalServerError, response.TranslateMsg(c, "BindFail"))
 			return
@@ -220,42 +195,41 @@ func (o *Oauth) OauthCallback(c *gin.Context) {
 		c.String(http.StatusOK, response.TranslateMsg(c, "BindSuccess"))
 		return
 
-	} else if ac == service.OauthActionTypeLogin {
+	} else if action == service.OauthActionTypeLogin {
 		//登录
-		if v.UserId != 0 {
+		if userId != 0 {
 			c.String(http.StatusInternalServerError, response.TranslateMsg(c, "OauthHasBeenSuccess"))
 			return
 		}
-		u = service.AllService.UserService.InfoByGithubId(openid)
-		if u == nil {
-			oa := service.AllService.OauthService.InfoByOp(ty)
-			if !*oa.AutoRegister {
+		user = service.AllService.UserService.InfoByOauthId(op, openid)
+		if user == nil {
+			oauthConfig := oauthService.InfoByOp(op)
+			if !*oauthConfig.AutoRegister {
 				//c.String(http.StatusInternalServerError, "还未绑定用户，请先绑定")
-				v.ThirdName = thirdName
-				v.ThirdOpenId = openid
+				oauthCache.UpdateFromOauthUser(oauthUser)
 				url := global.Config.Rustdesk.ApiServer + "/_admin/#/oauth/bind/" + cacheKey
 				c.Redirect(http.StatusFound, url)
 				return
 			}
 
 			//自动注册
-			u = service.AllService.UserService.RegisterByOauth(ty, thirdName, openid)
-			if u.Id == 0 {
+			user = service.AllService.UserService.RegisterByOauth(oauthUser, op)
+			if user.Id == 0 {
 				c.String(http.StatusInternalServerError, response.TranslateMsg(c, "OauthRegisterFailed"))
 				return
 			}
 		}
-		v.UserId = u.Id
-		service.AllService.OauthService.SetOauthCache(cacheKey, v, 0)
+		oauthCache.UserId = user.Id
+		oauthService.SetOauthCache(cacheKey, oauthCache, 0)
 		// 如果是webadmin，登录成功后跳转到webadmin
-		if v.DeviceType == "webadmin" {
+		if oauthCache.DeviceType == "webadmin" {
 			/*service.AllService.UserService.Login(u, &model.LoginLog{
 				UserId:   u.Id,
 				Client:   "webadmin",
 				Uuid:     "", //must be empty
 				Ip:       c.ClientIP(),
 				Type:     model.LoginLogTypeOauth,
-				Platform: v.DeviceOs,
+				Platform: oauthService.DeviceOs,
 			})*/
 			url := global.Config.Rustdesk.ApiServer + "/_admin/#/"
 			c.Redirect(http.StatusFound, url)

--- a/http/controller/api/ouath.go
+++ b/http/controller/api/ouath.go
@@ -94,6 +94,7 @@ func (o *Oauth) OidcAuthQueryPre(c *gin.Context) (*model.User, *model.UserToken)
 	ut = service.AllService.UserService.Login(u, &model.LoginLog{
 		UserId:   u.Id,
 		Client:   v.DeviceType,
+		DeviceId: v.Id,
 		Uuid:     v.Uuid,
 		Ip:       c.ClientIP(),
 		Type:     model.LoginLogTypeOauth,

--- a/http/request/admin/oauth.go
+++ b/http/request/admin/oauth.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"Gwen/model"
-	"strings"
 )
 
 type BindOauthForm struct {
@@ -28,22 +27,6 @@ type OauthForm struct {
 }
 
 func (of *OauthForm) ToOauth() *model.Oauth {
-	op := strings.ToLower(of.Op)
-	op = strings.TrimSpace(op)
-	if op == "" {
-		switch of.OauthType {
-		case model.OauthTypeGithub:
-			of.Op = model.OauthNameGithub
-		case model.OauthTypeGoogle:
-			of.Op = model.OauthNameGoogle
-		case model.OauthTypeOidc:
-			of.Op = model.OauthNameOidc
-		case model.OauthTypeWebauth:
-			of.Op = model.OauthNameWebauth
-		default:
-			of.Op = of.OauthType
-		}
-	}
 	oa := &model.Oauth{
 		Op:           of.Op,
 		OauthType:	  of.OauthType,

--- a/http/request/admin/oauth.go
+++ b/http/request/admin/oauth.go
@@ -1,6 +1,9 @@
 package admin
 
-import "Gwen/model"
+import (
+	"Gwen/model"
+	"strings"
+)
 
 type BindOauthForm struct {
 	Op string `json:"op" binding:"required"`
@@ -13,19 +16,37 @@ type UnBindOauthForm struct {
 	Op string `json:"op" binding:"required"`
 }
 type OauthForm struct {
-	Id           uint   `json:"id"`
-	Op           string `json:"op" validate:"required"`
-	Issuer	     string `json:"issuer" validate:"omitempty,url"`
-	Scopes	   	 string `json:"scopes" validate:"omitempty"`
-	ClientId     string `json:"client_id" validate:"required"`
-	ClientSecret string `json:"client_secret" validate:"required"`
-	RedirectUrl  string `json:"redirect_url" validate:"required"`
-	AutoRegister *bool  `json:"auto_register"`
+	Id           uint   			`json:"id"`
+	Op           string 			`json:"op" validate:"omitempty"`
+	OauthType    string 			`json:"oauth_type" validate:"required"`
+	Issuer	     string 			`json:"issuer" validate:"omitempty,url"`
+	Scopes	   	 string 			`json:"scopes" validate:"omitempty"`
+	ClientId     string 			`json:"client_id" validate:"required"`
+	ClientSecret string 			`json:"client_secret" validate:"required"`
+	RedirectUrl  string 			`json:"redirect_url" validate:"required"`
+	AutoRegister *bool  			`json:"auto_register"`
 }
 
 func (of *OauthForm) ToOauth() *model.Oauth {
+	op := strings.ToLower(of.Op)
+	op = strings.TrimSpace(op)
+	if op == "" {
+		switch of.OauthType {
+		case model.OauthTypeGithub:
+			of.Op = "GitHub"
+		case model.OauthTypeGoogle:
+			of.Op = "Google"
+		case model.OauthTypeOidc:
+			of.Op = "OIDC"
+		case model.OauthTypeWebauth:
+			of.Op = "WebAuth"
+		default:
+			of.Op = of.OauthType
+		}
+	}
 	oa := &model.Oauth{
 		Op:           of.Op,
+		OauthType:	  of.OauthType,
 		ClientId:     of.ClientId,
 		ClientSecret: of.ClientSecret,
 		RedirectUrl:  of.RedirectUrl,

--- a/http/request/admin/oauth.go
+++ b/http/request/admin/oauth.go
@@ -33,13 +33,13 @@ func (of *OauthForm) ToOauth() *model.Oauth {
 	if op == "" {
 		switch of.OauthType {
 		case model.OauthTypeGithub:
-			of.Op = "GitHub"
+			of.Op = model.OauthNameGithub
 		case model.OauthTypeGoogle:
-			of.Op = "Google"
+			of.Op = model.OauthNameGoogle
 		case model.OauthTypeOidc:
-			of.Op = "OIDC"
+			of.Op = model.OauthNameOidc
 		case model.OauthTypeWebauth:
-			of.Op = "WebAuth"
+			of.Op = model.OauthNameWebauth
 		default:
 			of.Op = of.OauthType
 		}

--- a/http/request/admin/user.go
+++ b/http/request/admin/user.go
@@ -5,20 +5,22 @@ import (
 )
 
 type UserForm struct {
-	Id       uint   `json:"id"`
-	Username string `json:"username" validate:"required,gte=4,lte=10"`
+	Id       uint   			`json:"id"`
+	Username string 			`json:"username" validate:"required,gte=4,lte=10"`
+	Email	 string           	`json:"email" validate:"required,email"`
 	//Password string           `json:"password" validate:"required,gte=4,lte=20"`
-	Nickname string           `json:"nickname"`
-	Avatar   string           `json:"avatar"`
-	GroupId  uint             `json:"group_id" validate:"required"`
-	IsAdmin  *bool            `json:"is_admin" `
-	Status   model.StatusCode `json:"status" validate:"required,gte=0"`
+	Nickname string           	`json:"nickname"`
+	Avatar   string           	`json:"avatar"`
+	GroupId  uint             	`json:"group_id" validate:"required"`
+	IsAdmin  *bool            	`json:"is_admin" `
+	Status   model.StatusCode 	`json:"status" validate:"required,gte=0"`
 }
 
 func (uf *UserForm) FromUser(user *model.User) *UserForm {
 	uf.Id = user.Id
 	uf.Username = user.Username
 	uf.Nickname = user.Nickname
+	uf.Email = user.Email
 	uf.Avatar = user.Avatar
 	uf.GroupId = user.GroupId
 	uf.IsAdmin = user.IsAdmin
@@ -30,6 +32,7 @@ func (uf *UserForm) ToUser() *model.User {
 	user.Id = uf.Id
 	user.Username = uf.Username
 	user.Nickname = uf.Nickname
+	user.Email = uf.Email
 	user.Avatar = uf.Avatar
 	user.GroupId = uf.GroupId
 	user.IsAdmin = uf.IsAdmin

--- a/http/request/admin/user.go
+++ b/http/request/admin/user.go
@@ -65,6 +65,7 @@ type GroupUsersQuery struct {
 
 type RegisterForm struct {
 	Username        string `json:"username" validate:"required,gte=4,lte=10"`
+	Email           string `json:"email" validate:"required,email"`
 	Password        string `json:"password" validate:"required,gte=4,lte=20"`
 	ConfirmPassword string `json:"confirm_password" validate:"required,gte=4,lte=20"`
 }

--- a/http/response/admin/user.go
+++ b/http/response/admin/user.go
@@ -11,6 +11,13 @@ type LoginPayload struct {
 	Nickname   string   `json:"nickname"`
 }
 
+func (lp *LoginPayload) FromUser(user *model.User) {
+	lp.Username = user.Username
+	lp.Email = user.Email
+	lp.Avatar = user.Avatar
+	lp.Nickname = user.Nickname
+}
+
 var UserRouteNames = []string{
 	"MyTagList", "MyAddressBookList", "MyInfo", "MyAddressBookCollection", "MyPeer",
 }

--- a/http/response/admin/user.go
+++ b/http/response/admin/user.go
@@ -4,6 +4,8 @@ import "Gwen/model"
 
 type LoginPayload struct {
 	Username   string   `json:"username"`
+	Email	   string   `json:"email"`
+	Avatar	   string   `json:"avatar"`
 	Token      string   `json:"token"`
 	RouteNames []string `json:"route_names"`
 	Nickname   string   `json:"nickname"`
@@ -15,8 +17,8 @@ var UserRouteNames = []string{
 var AdminRouteNames = []string{"*"}
 
 type UserOauthItem struct {
-	ThirdType string `json:"third_type"`
-	Status    int    `json:"status"`
+	Op 			string `json:"op"`
+	Status    	int    `json:"status"`
 }
 
 type GroupUsersPayload struct {

--- a/http/response/admin/user.go
+++ b/http/response/admin/user.go
@@ -12,7 +12,7 @@ type LoginPayload struct {
 }
 
 var UserRouteNames = []string{
-	"MyTagList", "MyAddressBookList", "MyInfo", "MyAddressBookCollection",
+	"MyTagList", "MyAddressBookList", "MyInfo", "MyAddressBookCollection", "MyPeer",
 }
 var AdminRouteNames = []string{"*"}
 

--- a/http/response/api/user.go
+++ b/http/response/api/user.go
@@ -29,6 +29,7 @@ type UserPayload struct {
 
 func (up *UserPayload) FromUser(user *model.User) *UserPayload {
 	up.Name = user.Username
+	up.Email = user.Email
 	up.IsAdmin = user.IsAdmin
 	up.Status = int(user.Status)
 	up.Info = map[string]interface{}{}

--- a/http/router/admin.go
+++ b/http/router/admin.go
@@ -53,6 +53,7 @@ func UserBind(rg *gin.RouterGroup) {
 		aR.GET("/current", cont.Current)
 		aR.POST("/changeCurPwd", cont.ChangeCurPwd)
 		aR.POST("/myOauth", cont.MyOauth)
+		aR.GET("/myPeer", cont.MyPeer)
 		aR.POST("/groupUsers", cont.GroupUsers)
 	}
 	aRP := rg.Group("/user").Use(middleware.AdminPrivilege())

--- a/model/loginLog.go
+++ b/model/loginLog.go
@@ -4,6 +4,7 @@ type LoginLog struct {
 	IdModel
 	UserId      uint   `json:"user_id" gorm:"default:0;not null;"`
 	Client      string `json:"client"` //webadmin,webclient,app,
+	DeviceId	string `json:"device_id"`
 	Uuid        string `json:"uuid"`
 	Ip          string `json:"ip"`
 	Type        string `json:"type"`     //account,oauth

--- a/model/oauth.go
+++ b/model/oauth.go
@@ -119,6 +119,7 @@ func (gu *GithubUser) ToOauthUser() *OauthUser {
 		Username: 		gu.Login,
 		Email:  		gu.Email,
 		VerifiedEmail: 	gu.VerifiedEmail,
+		Picture:		gu.AvatarUrl,
 	}
 }
 

--- a/model/oauth.go
+++ b/model/oauth.go
@@ -1,23 +1,110 @@
 package model
 
+import (
+	"strconv"
+	"fmt"
+)
+
+
+const (
+	OauthTypeGithub  string = "github"
+	OauthTypeGoogle  string = "google"
+	OauthTypeOidc    string = "oidc"
+	OauthTypeWebauth string = "webauth"
+)
+
+
 type Oauth struct {
 	IdModel
-	Op           string `json:"op"`
-	ClientId     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
-	RedirectUrl  string `json:"redirect_url"`
-	AutoRegister *bool  `json:"auto_register"`
-	Scopes       string `json:"scopes"`
-	Issuer	     string `json:"issuer"`
+	Op           string 	`json:"op"`
+	OauthType    string 	`json:"oauth_type"`
+	ClientId     string 	`json:"client_id"`
+	ClientSecret string 	`json:"client_secret"`
+	RedirectUrl  string 	`json:"redirect_url"`
+	AutoRegister *bool  	`json:"auto_register"`
+	Scopes       string 	`json:"scopes"`
+	Issuer	     string 	`json:"issuer"`
 	TimeModel
 }
 
-const (
-	OauthTypeGithub  = "github"
-	OauthTypeGoogle  = "google"
-	OauthTypeOidc    = "oidc"
-	OauthTypeWebauth = "webauth"
-)
+type OauthUser struct {
+	OpenId 			string 	`json:"open_id" gorm:"not null;index"`
+	Name   			string 	`json:"name"`
+	Username 		string 	`json:"username"`
+	Email  			string 	`json:"email"`
+	VerifiedEmail 	bool 	`json:"verified_email,omitempty"`
+}
+
+func (ou *OauthUser) ToUser(user *User, overideUsername bool) {
+	if overideUsername {
+		user.Username = ou.Username
+	}
+	user.Email = ou.Email
+	user.Nickname = ou.Name
+
+}
+
+
+type OauthUserBase struct {
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+
+type OidcUser struct {
+	OauthUserBase
+	Sub               string `json:"sub"`
+	VerifiedEmail     bool   `json:"email_verified"`
+	PreferredUsername string `json:"preferred_username"`
+}
+
+func (ou *OidcUser) ToOauthUser() *OauthUser {
+	return &OauthUser{
+		OpenId: 		ou.Sub,
+		Name:   		ou.Name,
+		Username: 		ou.PreferredUsername,
+		Email:  		ou.Email,
+		VerifiedEmail: 	ou.VerifiedEmail,
+	}
+}
+
+type GoogleUser struct {
+	OauthUserBase
+	FamilyName    string `json:"family_name"`
+	GivenName     string `json:"given_name"`
+	Id            string `json:"id"`
+	Picture       string `json:"picture"`
+	VerifiedEmail bool   `json:"verified_email"`
+}
+
+func (gu *GoogleUser) ToOauthUser() *OauthUser {
+	return &OauthUser{
+		OpenId: 		gu.Id,
+		Name:   		fmt.Sprintf("%s %s", gu.GivenName, gu.FamilyName),
+		Username: 		gu.GivenName,
+		Email:  		gu.Email,
+		VerifiedEmail: 	gu.VerifiedEmail,
+	}	
+}
+
+
+type GithubUser struct {
+	OauthUserBase
+	Id                int         `json:"id"`
+	Login             string      `json:"login"`
+}
+
+func (gu *GithubUser) ToOauthUser() *OauthUser {
+	return &OauthUser{
+		OpenId: 		strconv.Itoa(gu.Id),
+		Name:   		gu.Name,
+		Username: 		gu.Login,
+		Email:  		gu.Email,
+		VerifiedEmail: 	true,
+	}
+}
+
+
 
 type OauthList struct {
 	Oauths []*Oauth `json:"list"`

--- a/model/oauth.go
+++ b/model/oauth.go
@@ -13,6 +13,18 @@ const (
 	OauthTypeWebauth string = "webauth"
 )
 
+const (
+	OauthNameGithub  string = "GitHub"
+	OauthNameGoogle  string = "Google"
+	OauthNameOidc    string = "OIDC"
+	OauthNameWebauth string = "WebAuth"
+)
+
+const (
+	UserEndpointGithub  string = "https://api.github.com/user"
+	UserEndpointGoogle  string = "https://www.googleapis.com/oauth2/v3/userinfo"
+	UserEndpointOidc    string = ""
+)
 
 type Oauth struct {
 	IdModel
@@ -33,6 +45,7 @@ type OauthUser struct {
 	Username 		string 	`json:"username"`
 	Email  			string 	`json:"email"`
 	VerifiedEmail 	bool 	`json:"verified_email,omitempty"`
+	Picture			string 	`json:"picture,omitempty"`
 }
 
 func (ou *OauthUser) ToUser(user *User, overideUsername bool) {
@@ -56,6 +69,7 @@ type OidcUser struct {
 	Sub               string `json:"sub"`
 	VerifiedEmail     bool   `json:"email_verified"`
 	PreferredUsername string `json:"preferred_username"`
+	Picture		   	  string `json:"picture"`
 }
 
 func (ou *OidcUser) ToOauthUser() *OauthUser {
@@ -65,6 +79,7 @@ func (ou *OidcUser) ToOauthUser() *OauthUser {
 		Username: 		ou.PreferredUsername,
 		Email:  		ou.Email,
 		VerifiedEmail: 	ou.VerifiedEmail,
+		Picture:		ou.Picture,
 	}
 }
 
@@ -84,6 +99,7 @@ func (gu *GoogleUser) ToOauthUser() *OauthUser {
 		Username: 		gu.GivenName,
 		Email:  		gu.Email,
 		VerifiedEmail: 	gu.VerifiedEmail,
+		Picture:		gu.Picture,
 	}	
 }
 
@@ -92,6 +108,8 @@ type GithubUser struct {
 	OauthUserBase
 	Id                int         `json:"id"`
 	Login             string      `json:"login"`
+	AvatarUrl         string      `json:"avatar_url"`
+	VerifiedEmail	  bool        `json:"verified_email"`
 }
 
 func (gu *GithubUser) ToOauthUser() *OauthUser {
@@ -100,7 +118,7 @@ func (gu *GithubUser) ToOauthUser() *OauthUser {
 		Name:   		gu.Name,
 		Username: 		gu.Login,
 		Email:  		gu.Email,
-		VerifiedEmail: 	true,
+		VerifiedEmail: 	gu.VerifiedEmail,
 	}
 }
 

--- a/model/oauth.go
+++ b/model/oauth.go
@@ -54,7 +54,7 @@ func (ou *OauthUser) ToUser(user *User, overideUsername bool) {
 	}
 	user.Email = ou.Email
 	user.Nickname = ou.Name
-
+	user.Avatar = ou.Picture
 }
 
 

--- a/model/user.go
+++ b/model/user.go
@@ -1,8 +1,15 @@
 package model
 
+import (
+	"fmt"
+	"gorm.io/gorm"
+)
+
 type User struct {
 	IdModel
 	Username string     `json:"username" gorm:"default:'';not null;uniqueIndex"`
+	Email	string     	`json:"email" gorm:"default:'';not null;uniqueIndex"`
+	// Email	string     	`json:"email" `
 	Password string     `json:"-" gorm:"default:'';not null;"`
 	Nickname string     `json:"nickname" gorm:"default:'';not null;"`
 	Avatar   string     `json:"avatar" gorm:"default:'';not null;"`
@@ -10,6 +17,15 @@ type User struct {
 	IsAdmin  *bool      `json:"is_admin" gorm:"default:0;not null;"`
 	Status   StatusCode `json:"status" gorm:"default:1;not null;"`
 	TimeModel
+}
+
+// BeforeSave 钩子用于确保 email 字段有合理的默认值
+func (u *User) BeforeSave(tx *gorm.DB) (err error) {
+    // 如果 email 为空，设置为默认值
+    if u.Email == "" {
+        u.Email = fmt.Sprintf("%s@example.com", u.Username)
+    }
+    return nil
 }
 
 type UserList struct {

--- a/model/userThird.go
+++ b/model/userThird.go
@@ -2,11 +2,18 @@ package model
 
 type UserThird struct {
 	IdModel
-	UserId     uint   `json:"user_id" gorm:"not null;index"`
-	OpenId     string `json:"open_id" gorm:"not null;index"`
-	UnionId    string `json:"union_id" gorm:"not null;"`
-	ThirdType  string `json:"third_type" gorm:"not null;"`
-	ThirdEmail string `json:"third_email"`
-	ThirdName  string `json:"third_name"`
+	UserId     		uint   `	json:"user_id" gorm:"not null;index"`
+	OauthUser
+	// UnionId    		string `json:"union_id" gorm:"not null;"`
+	// OauthType  	   	string 		`json:"oauth_type" gorm:"not null;"`
+	OauthType  	   	string 		`json:"oauth_type"`
+	Op  			string 		`json:"op" gorm:"not null;"`
 	TimeModel
+}
+
+func (u *UserThird) FromOauthUser(userId uint, oauthUser *OauthUser, oauthType string, op string) {
+	u.UserId 			= userId
+	u.OauthUser 		= *oauthUser
+	u.OauthType 		= oauthType
+	u.Op 				= op
 }

--- a/model/userThird.go
+++ b/model/userThird.go
@@ -1,5 +1,9 @@
 package model
 
+import (
+	"strings"
+)
+
 type UserThird struct {
 	IdModel
 	UserId     		uint   `	json:"user_id" gorm:"not null;index"`
@@ -16,4 +20,6 @@ func (u *UserThird) FromOauthUser(userId uint, oauthUser *OauthUser, oauthType s
 	u.OauthUser 		= *oauthUser
 	u.OauthType 		= oauthType
 	u.Op 				= op
+	// make sure email is lower case
+	u.Email 			= strings.ToLower(u.Email)
 }

--- a/model/userToken.go
+++ b/model/userToken.go
@@ -2,9 +2,10 @@ package model
 
 type UserToken struct {
 	IdModel
-	UserId    uint   `json:"user_id" gorm:"default:0;not null;index"`
-	Token     string `json:"token" gorm:"default:'';not null;index"`
-	ExpiredAt int64  `json:"expired_at" gorm:"default:0;not null;"`
+	UserId    	uint   `json:"user_id" gorm:"default:0;not null;index"`
+	DeviceUuid 	string `json:"device_uuid"`
+	Token     	string `json:"token" gorm:"default:'';not null;index"`
+	ExpiredAt 	int64  `json:"expired_at" gorm:"default:0;not null;"`
 	TimeModel
 }
 

--- a/model/userToken.go
+++ b/model/userToken.go
@@ -3,7 +3,8 @@ package model
 type UserToken struct {
 	IdModel
 	UserId    	uint   `json:"user_id" gorm:"default:0;not null;index"`
-	DeviceUuid 	string `json:"device_uuid"`
+	DeviceUuid 	string `json:"device_uuid" gorm:"default:'';omitempty;"`
+	DeviceId	string `json:"device_id" gorm:"default:'';omitempty;"`
 	Token     	string `json:"token" gorm:"default:'';not null;index"`
 	ExpiredAt 	int64  `json:"expired_at" gorm:"default:0;not null;"`
 	TimeModel

--- a/service/oauth.go
+++ b/service/oauth.go
@@ -170,7 +170,7 @@ func (os *OauthService) GetOauthConfig(op string) (err error, oauthInfo *model.O
 		oauthConfig.Scopes = []string{"read:user", "user:email"}
 	case model.OauthTypeGoogle:
 		oauthConfig.Endpoint = google.Endpoint
-		oauthConfig.Scopes = []string{"https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/userinfo.email"}
+		oauthConfig.Scopes = os.constructScopes(model.OIDC_DEFAULT_SCOPES)
 	case model.OauthTypeOidc:
 		var endpoint OidcEndpoint
 		err, endpoint = os.FetchOidcEndpoint(oauthInfo.Issuer)
@@ -374,7 +374,7 @@ func (os *OauthService) getScopesByOp(op string) []string {
 func (os *OauthService) constructScopes(scopes string) []string {
     scopes = strings.TrimSpace(scopes)
     if scopes == "" {
-        scopes = "openid,profile,email"
+        scopes = model.OIDC_DEFAULT_SCOPES
     }
     return strings.Split(scopes, ",")
 }

--- a/service/oauth.go
+++ b/service/oauth.go
@@ -106,15 +106,14 @@ func (os *OauthService) DeleteOauthCache(key string) {
 
 func (os *OauthService) BeginAuth(op string) (error error, code, url string) {
 	code = utils.RandomString(10) + strconv.FormatInt(time.Now().Unix(), 10)
-
 	if op == string(model.OauthTypeWebauth) {
 		url = global.Config.Rustdesk.ApiServer + "/_admin/#/oauth/" + code
 		//url = "http://localhost:8888/_admin/#/oauth/" + code
 		return nil, code, url
 	}
-	err, _, conf := os.GetOauthConfig(op)
+	err, _, oauthConfig := os.GetOauthConfig(op)
 	if err == nil {
-		return err, code, conf.AuthCodeURL(code)
+		return err, code, oauthConfig.AuthCodeURL(code)
 	}
 
 	return err, code, ""
@@ -154,16 +153,17 @@ func (os *OauthService) FetchOidcEndpointByOp(op string) (error, OidcEndpoint) {
 }
 
 // GetOauthConfig retrieves the OAuth2 configuration based on the provider name
-func (os *OauthService) GetOauthConfig(op string) (err error, oauthType string, oauthConfig *oauth2.Config) {
-	err = os.ValidateOauthProvider(op)
+func (os *OauthService) GetOauthConfig(op string) (err error, oauthInfo *model.Oauth, oauthConfig *oauth2.Config) {
+	err, oauthInfo, oauthConfig = os.getOauthConfigGeneral(op)
 	if err != nil {
-		return err, "", nil
-	}
-	err, oauthType, oauthConfig = os.getOauthConfigGeneral(op)
-	if err != nil {
-		return err, oauthType, nil
+		return err, nil, nil
 	}
 	// Maybe should validate the oauthConfig here
+	oauthType := oauthInfo.OauthType
+	err = os.ValidateOauthType(oauthType)
+	if err != nil {
+		return err, nil, nil
+	}
 	switch oauthType {
 	case model.OauthTypeGithub:
 		oauthConfig.Endpoint = github.Endpoint
@@ -172,32 +172,33 @@ func (os *OauthService) GetOauthConfig(op string) (err error, oauthType string, 
 		oauthConfig.Endpoint = google.Endpoint
 		oauthConfig.Scopes = []string{"https://www.googleapis.com/auth/userinfo.profile", "https://www.googleapis.com/auth/userinfo.email"}
 	case model.OauthTypeOidc:
-		err, endpoint := os.FetchOidcEndpointByOp(op)
+		var endpoint OidcEndpoint
+		err, endpoint = os.FetchOidcEndpoint(oauthInfo.Issuer)
 		if err != nil {
-			return err,oauthType, nil
+			return err, nil, nil
 		}
 		oauthConfig.Endpoint = oauth2.Endpoint{AuthURL:  endpoint.AuthURL,TokenURL: endpoint.TokenURL,}
-		oauthConfig.Scopes = os.getScopesByOp(op)
+		oauthConfig.Scopes = os.constructScopes(oauthInfo.Scopes)
 	default:
-		return errors.New("unsupported OAuth type"), oauthType, nil
+		return errors.New("unsupported OAuth type"), nil, nil
 	}
-	return nil, oauthType, oauthConfig
+	return nil, oauthInfo, oauthConfig
 }
 
 // GetOauthConfig retrieves the OAuth2 configuration based on the provider name
-func (os *OauthService) getOauthConfigGeneral(op string) (err error, oauthType string, oauthConfig *oauth2.Config) {
-	g := os.InfoByOp(op)
-	if g.Id == 0 || g.ClientId == "" || g.ClientSecret == "" {
-		return errors.New("ConfigNotFound"), "", nil
+func (os *OauthService) getOauthConfigGeneral(op string) (err error, oauthInfo *model.Oauth, oauthConfig *oauth2.Config) {
+	oauthInfo = os.InfoByOp(op)
+	if oauthInfo.Id == 0 || oauthInfo.ClientId == "" || oauthInfo.ClientSecret == "" {
+		return errors.New("ConfigNotFound"), nil, nil
 	}
 	// If the redirect URL is empty, use the default redirect URL
-	if g.RedirectUrl == "" {
-		g.RedirectUrl = global.Config.Rustdesk.ApiServer + "/api/oidc/callback"
+	if oauthInfo.RedirectUrl == "" {
+		oauthInfo.RedirectUrl = global.Config.Rustdesk.ApiServer + "/api/oidc/callback"
 	}
-	return nil, g.OauthType, &oauth2.Config{
-		ClientID:     g.ClientId,
-		ClientSecret: g.ClientSecret,
-		RedirectURL:  g.RedirectUrl,
+	return nil, oauthInfo, &oauth2.Config{
+		ClientID:     oauthInfo.ClientId,
+		ClientSecret: oauthInfo.ClientSecret,
+		RedirectURL:  oauthInfo.RedirectUrl,
 	}
 }
 
@@ -221,40 +222,26 @@ func getHTTPClientWithProxy() *http.Client {
 	return http.DefaultClient
 }
 
-func (os *OauthService) callbackBase(op string, code string, userEndpoint string, userData interface{}) error {
-	err, oauthType, oauthConfig := os.GetOauthConfig(op)
-	if err != nil {
-		return err
-	}
-	
-	// If the OAuth type is OIDC and the user endpoint is empty
-	// Fetch the OIDC configuration and get the user endpoint
-	if oauthType == model.OauthTypeOidc && userEndpoint == "" {
-		err, endpoint := os.FetchOidcEndpointByOp(op)
-		if err != nil {
-			global.Logger.Warn("failed fetching OIDC configuration: ", err)
-			return errors.New("FetchOidcEndpointError")
-		}
-		userEndpoint = endpoint.UserInfo
-	}
+func (os *OauthService) callbackBase(oauthConfig *oauth2.Config, code string, userEndpoint string, userData interface{}) (err error, client *http.Client) {
 
 	// 设置代理客户端
 	httpClient := getHTTPClientWithProxy()
 	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, httpClient)
 
 	// 使用 code 换取 token
-	token, err := oauthConfig.Exchange(ctx, code)
+	var token *oauth2.Token
+	token, err = oauthConfig.Exchange(ctx, code)
 	if err != nil {
 		global.Logger.Warn("oauthConfig.Exchange() failed: ", err)
-		return errors.New("GetOauthTokenError")
+		return errors.New("GetOauthTokenError"), nil
 	}
 
 	// 获取用户信息
-	client := oauthConfig.Client(ctx, token)
+	client = oauthConfig.Client(ctx, token)
 	resp, err := client.Get(userEndpoint)
 	if err != nil {
 		global.Logger.Warn("failed getting user info: ", err)
-		return errors.New("GetOauthUserInfoError")
+		return errors.New("GetOauthUserInfoError"), nil
 	}
 	defer func() {
 		if closeErr := resp.Body.Close(); closeErr != nil {
@@ -265,36 +252,39 @@ func (os *OauthService) callbackBase(op string, code string, userEndpoint string
 	// 解析用户信息
 	if err = json.NewDecoder(resp.Body).Decode(userData); err != nil {
 		global.Logger.Warn("failed decoding user info: ", err)
-		return errors.New("DecodeOauthUserInfoError")
+		return errors.New("DecodeOauthUserInfoError"), nil
 	}
 
-	return nil
+	return nil, client
 }
 
 // githubCallback github回调
-func (os *OauthService) githubCallback(code string) (error, *model.OauthUser) {
+func (os *OauthService) githubCallback(oauthConfig *oauth2.Config, code string) (error, *model.OauthUser) {
 	var user = &model.GithubUser{}
-	const userEndpoint = "https://api.github.com/user"
-	if err := os.callbackBase(model.OauthTypeGithub, code, userEndpoint, user); err != nil {
+	err, client := os.callbackBase(oauthConfig, code, model.UserEndpointGithub, user)
+	if err != nil {
+		return err, nil
+	}
+	err = os.getGithubPrimaryEmail(client, user)
+	if err != nil {
 		return err, nil
 	}
 	return nil, user.ToOauthUser()
 }
 
 // googleCallback google回调
-func (os *OauthService) googleCallback(code string) (error, *model.OauthUser) {
+func (os *OauthService) googleCallback(oauthConfig *oauth2.Config, code string) (error, *model.OauthUser) {
 	var user = &model.GoogleUser{}
-	const userEndpoint = "https://www.googleapis.com/oauth2/v2/userinfo"
-	if err := os.callbackBase(model.OauthTypeGoogle, code, userEndpoint, user); err != nil {
+	if err, _ := os.callbackBase(oauthConfig, code, model.UserEndpointGoogle, user); err != nil {
 		return err, nil
 	}
 	return nil, user.ToOauthUser()
 }
 
 // oidcCallback oidc回调, 通过code获取用户信息
-func (os *OauthService) oidcCallback(code string, op string) (error, *model.OauthUser,) {
+func (os *OauthService) oidcCallback(oauthConfig *oauth2.Config, code string, userInfoEndpoint string) (error, *model.OauthUser,) {
 	var user = &model.OidcUser{}
-	if err := os.callbackBase(op, code, "", user); err != nil {
+	if err, _ := os.callbackBase(oauthConfig, code, userInfoEndpoint, user); err != nil {
 		return err, nil
 	}
 	return nil, user.ToOauthUser()
@@ -302,22 +292,28 @@ func (os *OauthService) oidcCallback(code string, op string) (error, *model.Oaut
 
 // Callback: Get user information by code and op(Oauth provider)
 func (os *OauthService) Callback(code string, op string) (err error, oauthUser *model.OauthUser) {
-    oauthType := os.GetTypeByOp(op)
-    if err = os.ValidateOauthType(oauthType); err != nil {
-        return err, nil
-    }
-    
-    switch oauthType {
+	var oauthInfo *model.Oauth
+	var oauthConfig *oauth2.Config
+	err, oauthInfo, oauthConfig = os.GetOauthConfig(op)
+	// oauthType is already validated in GetOauthConfig
+	if err != nil {
+		return err, nil
+	}
+	oauthType := oauthInfo.OauthType
+	switch oauthType {
     case model.OauthTypeGithub:
-        err, oauthUser = os.githubCallback(code)
+        err, oauthUser = os.githubCallback(oauthConfig, code)
     case model.OauthTypeGoogle:
-        err, oauthUser = os.googleCallback(code)
+        err, oauthUser = os.googleCallback(oauthConfig, code)
     case model.OauthTypeOidc:
-        err, oauthUser = os.oidcCallback(code, op)
+		err, endpoint := os.FetchOidcEndpoint(oauthInfo.Issuer)
+		if err != nil {
+			return err, nil
+		}
+        err, oauthUser = os.oidcCallback(oauthConfig, code, endpoint.UserInfo)
     default:
         return errors.New("unsupported OAuth type"), nil
     }
-    
     return err, oauthUser
 }
 
@@ -331,7 +327,10 @@ func (os *OauthService) UserThirdInfo(op string, openId string) *model.UserThird
 // BindOauthUser: Bind third party account
 func (os *OauthService) BindOauthUser(userId uint, oauthUser *model.OauthUser, op string) error {
 	utr := &model.UserThird{}
-	oauthType := os.GetTypeByOp(op)
+	err, oauthType := os.GetTypeByOp(op)
+	if err != nil {
+		return err
+	}
 	utr.FromOauthUser(userId, oauthUser, oauthType, op)
 	return global.DB.Create(utr).Error
 }
@@ -368,13 +367,17 @@ func (os *OauthService) InfoByOp(op string) *model.Oauth {
 // Helper function to get scopes by operation
 func (os *OauthService) getScopesByOp(op string) []string {
     scopes := os.InfoByOp(op).Scopes
-    scopes = strings.TrimSpace(scopes) // 这里使用 `=` 而不是 `:=`，避免重新声明变量
+	return os.constructScopes(scopes)
+}
+
+// Helper function to construct scopes
+func (os *OauthService) constructScopes(scopes string) []string {
+    scopes = strings.TrimSpace(scopes)
     if scopes == "" {
         scopes = "openid,profile,email"
     }
     return strings.Split(scopes, ",")
 }
-
 
 func (os *OauthService) List(page, pageSize uint, where func(tx *gorm.DB)) (res *model.OauthList) {
 	res = &model.OauthList{}
@@ -391,21 +394,30 @@ func (os *OauthService) List(page, pageSize uint, where func(tx *gorm.DB)) (res 
 }
 
 // GetTypeByOp 根据op获取OauthType
-func (os *OauthService) GetTypeByOp(op string) string {
+func (os *OauthService) GetTypeByOp(op string) (error, string) {
 	oauthInfo := &model.Oauth{}
 	if global.DB.Where("op = ?", op).First(oauthInfo).Error != nil {
-		return ""
+		return fmt.Errorf("OAuth provider with op '%s' not found", op), ""
 	}
-	return oauthInfo.OauthType
+	return nil, oauthInfo.OauthType
 }
 
+// ValidateOauthProvider 验证Oauth提供者是否正确
 func (os *OauthService) ValidateOauthProvider(op string) error {
+	if !os.IsOauthProviderExist(op) {
+		return fmt.Errorf("OAuth provider with op '%s' not found", op)
+	}
+	return nil
+}
+
+// IsOauthProviderExist 验证Oauth提供者是否存在
+func (os *OauthService) IsOauthProviderExist(op string) bool {
 	oauthInfo := &model.Oauth{}
-    // 使用 Gorm 的 Take 方法查找符合条件的记录
-    if err := global.DB.Where("op = ?", op).Take(oauthInfo).Error; err != nil {
-        return fmt.Errorf("OAuth provider with op '%s' not found: %w", op, err)
-    }
-    return nil
+	// 使用 Gorm 的 Take 方法查找符合条件的记录
+	if err := global.DB.Where("op = ?", op).Take(oauthInfo).Error; err != nil {
+		return false
+	}
+	return true
 }
 
 // Create 创建
@@ -427,4 +439,41 @@ func (os *OauthService) GetOauthProviders() []string {
 	var res []string
 	global.DB.Model(&model.Oauth{}).Pluck("op", &res)
 	return res
+}
+
+// getGithubPrimaryEmail: Get the primary email of the user from Github
+func (os *OauthService) getGithubPrimaryEmail(client *http.Client, githubUser *model.GithubUser) error {
+	// the client is already set with the token
+	resp, err := client.Get("https://api.github.com/user/emails")
+	if err != nil {
+		return fmt.Errorf("failed to fetch emails: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// check the response status code
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to fetch emails: %s", resp.Status)
+	}
+
+	// decode the response
+	var emails []struct {
+		Email    string `json:"email"`
+		Primary  bool   `json:"primary"`
+		Verified bool   `json:"verified"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&emails); err != nil {
+		return fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	// find the primary verified email
+	for _, e := range emails {
+		if e.Primary && e.Verified {
+			githubUser.Email = e.Email
+			githubUser.VerifiedEmail = e.Verified
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no primary verified email found")
 }

--- a/service/oauth.go
+++ b/service/oauth.go
@@ -155,6 +155,10 @@ func (os *OauthService) FetchOidcEndpointByOp(op string) (error, OidcEndpoint) {
 
 // GetOauthConfig retrieves the OAuth2 configuration based on the provider name
 func (os *OauthService) GetOauthConfig(op string) (err error, oauthType string, oauthConfig *oauth2.Config) {
+	err = os.ValidateOauthProvider(op)
+	if err != nil {
+		return err, "", nil
+	}
 	err, oauthType, oauthConfig = os.getOauthConfigGeneral(op)
 	if err != nil {
 		return err, oauthType, nil

--- a/service/peer.go
+++ b/service/peer.go
@@ -26,12 +26,27 @@ func (ps *PeerService) InfoByRowId(id uint) *model.Peer {
 	return p
 }
 
+// FindByUserIdAndUuid 根据用户id和uuid查找peer
+func (ps *PeerService) FindByUserIdAndUuid(uuid string,userId uint) *model.Peer {
+	p := &model.Peer{}
+	global.DB.Where("uuid = ? and user_id = ?", uuid, userId).First(p)
+	return p
+}
+
 // UuidBindUserId 绑定用户id
 func (ps *PeerService) UuidBindUserId(uuid string, userId uint) {
 	peer := ps.FindByUuid(uuid)
 	if peer.RowId > 0 {
 		peer.UserId = userId
 		ps.Update(peer)
+	}
+}
+
+// UuidUnbindUserId 解绑用户id, 用于用户注销
+func (ps *PeerService) UuidUnbindUserId(uuid string, userId uint) {
+	peer := ps.FindByUserIdAndUuid(uuid, userId)
+	if peer.RowId > 0 {
+		global.DB.Model(peer).Update("user_id", 0)
 	}
 }
 

--- a/service/peer.go
+++ b/service/peer.go
@@ -77,6 +77,18 @@ func (ps *PeerService) List(page, pageSize uint, where func(tx *gorm.DB)) (res *
 	return
 }
 
+// ListFilterByUserId 根据用户id过滤Peer列表
+func (ps *PeerService) ListFilterByUserId(page, pageSize uint, where func(tx *gorm.DB), userId uint) (res *model.PeerList) {
+	userWhere := func(tx *gorm.DB) {
+		tx.Where("user_id = ?", userId)
+		// 如果还有额外的筛选条件，执行它
+		if where != nil {
+			where(tx)
+		}
+	}
+	return ps.List(page, pageSize, userWhere)
+}
+
 // Create 创建
 func (ps *PeerService) Create(u *model.Peer) error {
 	res := global.DB.Create(u).Error

--- a/service/peer.go
+++ b/service/peer.go
@@ -58,6 +58,11 @@ func (ps *PeerService) UuidUnbindUserId(uuid string, userId uint) {
 	}
 }
 
+// EraseUserId 清除用户id, 用于用户删除
+func (ps *PeerService) EraseUserId(userId uint) error {
+	return global.DB.Model(&model.Peer{}).Where("user_id = ?", userId).Update("user_id", 0).Error
+}
+
 // ListByUserIds 根据用户id取列表
 func (ps *PeerService) ListByUserIds(userIds []uint, page, pageSize uint) (res *model.PeerList) {
 	res = &model.PeerList{}

--- a/service/peer.go
+++ b/service/peer.go
@@ -34,11 +34,19 @@ func (ps *PeerService) FindByUserIdAndUuid(uuid string,userId uint) *model.Peer 
 }
 
 // UuidBindUserId 绑定用户id
-func (ps *PeerService) UuidBindUserId(uuid string, userId uint) {
+func (ps *PeerService) UuidBindUserId(deviceId string, uuid string, userId uint) {
 	peer := ps.FindByUuid(uuid)
+	// 如果存在则更新
 	if peer.RowId > 0 {
 		peer.UserId = userId
 		ps.Update(peer)
+	} else {
+		// 不存在则创建
+		global.DB.Create(&model.Peer{
+			Id: 		deviceId,
+			Uuid:     	uuid,
+			UserId:   	userId,
+		})
 	}
 }
 

--- a/service/user.go
+++ b/service/user.go
@@ -220,6 +220,16 @@ func (us *UserService) FlushToken(u *model.User) error {
 	return global.DB.Where("user_id = ?", u.Id).Delete(&model.UserToken{}).Error
 }
 
+// FlushTokenByUuid 清空token
+func (us *UserService) FlushTokenByUuid(uuid string) error {
+	return global.DB.Where("device_uuid = ?", uuid).Delete(&model.UserToken{}).Error
+}
+
+// FlushTokenByUuids 清空token
+func (us *UserService) FlushTokenByUuids(uuids []string) error {
+	return global.DB.Where("device_uuid in (?)", uuids).Delete(&model.UserToken{}).Error
+}
+
 // UpdatePassword 更新密码
 func (us *UserService) UpdatePassword(u *model.User, password string) error {
 	u.Password = us.EncryptPassword(password)

--- a/service/user.go
+++ b/service/user.go
@@ -83,7 +83,7 @@ func (us *UserService) Login(u *model.User, llog *model.LoginLog) *model.UserTok
 	llog.UserTokenId = ut.UserId
 	global.DB.Create(llog)
 	if llog.Uuid != "" {
-		AllService.PeerService.UuidBindUserId(llog.Uuid, u.Id)
+		AllService.PeerService.UuidBindUserId(llog.DeviceId, llog.Uuid, u.Id)
 	}
 	return ut
 }

--- a/service/user.go
+++ b/service/user.go
@@ -185,7 +185,7 @@ func (us *UserService) Logout(u *model.User, token string) error {
 // Delete 删除用户和oauth信息
 func (us *UserService) Delete(u *model.User) error {
 	userCount := us.getAdminUserCount()
-	if userCount <= 1 {
+	if userCount <= 1 && us.IsAdmin(u) {
 		return errors.New("The last admin user cannot be deleted")
 	}
 	tx := global.DB.Begin()

--- a/service/user.go
+++ b/service/user.go
@@ -207,6 +207,11 @@ func (us *UserService) Delete(u *model.User) error {
 		return err
 	}
 	tx.Commit()
+	// 删除关联的peer
+	if err := AllService.PeerService.EraseUserId(u.Id); err != nil {
+		tx.Rollback()
+		return err
+	}
 	return nil
 }
 

--- a/service/user.go
+++ b/service/user.go
@@ -227,10 +227,10 @@ func (us *UserService) Delete(u *model.User) error {
 func (us *UserService) Update(u *model.User) error {
 	currentUser := us.InfoById(u.Id)
 	// 如果当前用户是管理员并且 IsAdmin 不为空，进行检查
-	if currentUser.IsAdmin != nil && *currentUser.IsAdmin {
+	if us.IsAdmin(currentUser) {
 		adminCount := us.getAdminUserCount()
 		// 如果这是唯一的管理员，确保不能禁用或取消管理员权限
-		if adminCount <= 1 && (u.IsAdmin == nil || !*u.IsAdmin || u.Status == model.COMMON_STATUS_DISABLED) {
+		if adminCount <= 1 && ( !us.IsAdmin(u) || u.Status == model.COMMON_STATUS_DISABLED) {
 			return errors.New("The last admin user cannot be disabled or demoted")
 		}
 	}

--- a/service/user.go
+++ b/service/user.go
@@ -76,6 +76,7 @@ func (us *UserService) Login(u *model.User, llog *model.LoginLog) *model.UserTok
 		UserId:    	u.Id,
 		Token:     	token,
 		DeviceUuid: llog.Uuid,
+		DeviceId:   llog.DeviceId,
 		ExpiredAt: 	time.Now().Add(time.Hour * 24 * 7).Unix(),
 	}
 	global.DB.Create(ut)

--- a/service/user.go
+++ b/service/user.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"time"
 	"strings"
-	"fmt"
 )
 
 type UserService struct {
@@ -378,9 +377,10 @@ func (us *UserService) IsPasswordEmptyByUser(u *model.User) bool {
 }
 
 // Register 注册
-func (us *UserService) Register(username string, password string) *model.User {
+func (us *UserService) Register(username string, email string, password string) *model.User {
 	u := &model.User{
 		Username: username,
+		Email:    email,
 		Password: us.EncryptPassword(password),
 		GroupId:  1,
 	}


### PR DESCRIPTION
有点乱

## 变化
1. 在user中增加了email
2. 重构Oauth的逻辑
3. 修改了oauths表
4. 修改了user_thirds
5. 设备注销的时候，在Peer中取消uuid和uer的关联
6. 在用户界面，新增加“我的设备” 来展示已经登陆的客户端

## 说明
### Oauth自动注册变化
1. 如果存在与Oauth中email的用户，则不会创建新用户，而是直接关联
2. 如果用户不存在，创建用户的时候会使用Oauth中的Username（不同类型会使用不同的field), Name 和Email

### Oauth 认证流程变化
1. Oauth将根据不同类型来执行不同的流程，当前有4种类型，OIDC, GitHub, Google 和 Webauth
2. 客户端提供op (Oauth Provider), 后端会在设置中查找其对应的类型，然后执行不同的逻辑

前端对应PR:lejianwen/rustdesk-api-web/pull/5

## 数据库迁移
- [ ] 注意要对数据库进行迁移才可以正常运行
- [x] 验证google认证
- [x] 验证Github认证
- [x] 验证OIDC认证(Keycloak)

