### PR TITLE
fix: cannot delete user

### DIFF
--- a/service/user.go
+++ b/service/user.go
@@ -217,8 +217,8 @@ func (us *UserService) Delete(u *model.User) error {
 	}
 	tx.Commit()
 	// 删除关联的peer
-	if err := AllService.PeerService.EraseUserId(u.Id); err != nil {
-		return err
+	return AllService.PeerService.EraseUserId(u.Id); err != nil {
+		return errors.New("User deleted successfully, but failed to unlink peer.")
 	}
 	return nil
 }

--- a/service/user.go
+++ b/service/user.go
@@ -215,12 +215,11 @@ func (us *UserService) Delete(u *model.User) error {
 		tx.Rollback()
 		return err
 	}
+	tx.Commit()
 	// 删除关联的peer
 	if err := AllService.PeerService.EraseUserId(u.Id); err != nil {
-		tx.Rollback()
 		return err
 	}
-	tx.Commit()
 	return nil
 }
 


### PR DESCRIPTION
删除用户的时候，清除peer和user的关联的函数放错位置，导致删除用户操作失败