### PR TITLE
feat(i18n): replace hardcoded messages with translated strings

### DIFF
--- a/http/controller/admin/file.go
+++ b/http/controller/admin/file.go
@@ -38,7 +38,7 @@ func (f *File) Notify(c *gin.Context) {
 
 	res := global.Oss.Verify(c.Request)
 	if !res {
-		response.Fail(c, 101, "权限错误")
+		response.Fail(c, 101, response.TranslateMsg(c, "NoAccess"))
 		return
 	}
 	fm := &FileBack{}

--- a/http/controller/admin/oauth.go
+++ b/http/controller/admin/oauth.go
@@ -68,16 +68,16 @@ func (o *Oauth) Confirm(c *gin.Context) {
 	j := &adminReq.OauthConfirmForm{}
 	err := c.ShouldBindJSON(j)
 	if err != nil {
-		response.Fail(c, 101, "参数错误"+err.Error())
+		response.Fail(c, 101, response.TranslateMsg(c, "ParamsError")+err.Error())
 		return
 	}
 	if j.Code == "" {
-		response.Fail(c, 101, "参数错误: code 不存在")
+		response.Fail(c, 101, response.TranslateMsg(c, "ParamsError"))
 		return
 	}
 	v := service.AllService.OauthService.GetOauthCache(j.Code)
 	if v == nil {
-		response.Fail(c, 101, "授权已过期")
+		response.Fail(c, 101, response.TranslateMsg(c, "OauthExpired"))
 		return
 	}
 	u := service.AllService.UserService.CurUser(c)

--- a/http/middleware/admin.go
+++ b/http/middleware/admin.go
@@ -13,13 +13,13 @@ func BackendUserAuth() gin.HandlerFunc {
 		//测试先关闭
 		token := c.GetHeader("api-token")
 		if token == "" {
-			response.Fail(c, 403, "请先登录")
+			response.Fail(c, 403, response.TranslateMsg(c, "NeedLogin"))
 			c.Abort()
 			return
 		}
 		user, ut := service.AllService.UserService.InfoByAccessToken(token)
 		if user.Id == 0 {
-			response.Fail(c, 403, "请先登录")
+			response.Fail(c, 403, response.TranslateMsg(c, "NeedLogin"))
 			c.Abort()
 			return
 		}

--- a/http/middleware/admin_privilege.go
+++ b/http/middleware/admin_privilege.go
@@ -12,7 +12,7 @@ func AdminPrivilege() gin.HandlerFunc {
 		u := service.AllService.UserService.CurUser(c)
 
 		if !service.AllService.UserService.IsAdmin(u) {
-			response.Fail(c, 403, "无权限")
+			response.Fail(c, 403, response.TranslateMsg(c, "NoAccess"))
 			c.Abort()
 			return
 		}

--- a/http/middleware/jwt.go
+++ b/http/middleware/jwt.go
@@ -12,18 +12,18 @@ func JwtAuth() gin.HandlerFunc {
 		//测试先关闭
 		token := c.GetHeader("api-token")
 		if token == "" {
-			response.Fail(c, 403, "请先登录")
+			response.Fail(c, 403, response.TranslateMsg(c, "NeedLogin"))
 			c.Abort()
 			return
 		}
 		uid, err := global.Jwt.ParseToken(token)
 		if err != nil {
-			response.Fail(c, 403, "请先登录")
+			response.Fail(c, 403, response.TranslateMsg(c, "NeedLogin"))
 			c.Abort()
 			return
 		}
 		if uid == 0 {
-			response.Fail(c, 403, "请先登录")
+			response.Fail(c, 403, response.TranslateMsg(c, "NeedLogin"))
 			c.Abort()
 			return
 		}
@@ -34,12 +34,12 @@ func JwtAuth() gin.HandlerFunc {
 		//	Username: "测试用户",
 		//}
 		if user.Id == 0 {
-			response.Fail(c, 403, "请先登录")
+			response.Fail(c, 403, response.TranslateMsg(c, "NeedLogin"))
 			c.Abort()
 			return
 		}
 		if !service.AllService.UserService.CheckUserEnable(user) {
-			response.Fail(c, 101, "你已被禁用")
+			response.Fail(c, 101, response.TranslateMsg(c, "Banned"))
 			c.Abort()
 			return
 		}

--- a/resources/i18n/en.toml
+++ b/resources/i18n/en.toml
@@ -33,6 +33,11 @@ description = "No access."
 one = "No access."
 other = "No access."
 
+[NeedLogin]
+description = "Need login."
+one = "Please log in first."
+other = "Please log in first."
+
 [UsernameOrPasswordError]
 description = "Username or password error."
 one = "Username or password error."

--- a/resources/i18n/es.toml
+++ b/resources/i18n/es.toml
@@ -33,6 +33,11 @@ description = "No access."
 one = "Sin acceso."
 other = "Sin acceso."
 
+[NeedLogin]
+description = "Need login."
+one = "Por favor inicie sesión primero."
+other = "Por favor inicie sesión primero."
+
 [UsernameOrPasswordError]
 description = "Username or password error."
 one = "Error de usuario o contraseña."

--- a/resources/i18n/fr.toml
+++ b/resources/i18n/fr.toml
@@ -33,6 +33,11 @@ description = "No access."
 one = "Aucun d'access."
 other = "Aucun d'access."
 
+[NeedLogin]
+description = "Need login."
+one = "Veuillez d'abord vous connecter."
+other = "Veuillez d'abord vous connecter."
+
 [UsernameOrPasswordError]
 description = "Username or password error."
 one = "Nom d'utilisateur ou de mot de passe incorrect."

--- a/resources/i18n/ko.toml
+++ b/resources/i18n/ko.toml
@@ -33,6 +33,11 @@ description = "No access."
 one = "접근할 수 없습니다."
 other = "접근할 수 없습니다."
 
+[NeedLogin]
+description = "Need login."
+one = "먼저 로그인해주세요."
+other = "먼저 로그인해주세요."
+
 [UsernameOrPasswordError]
 description = "Username or password error."
 one = "사용자 이름이나 비밀번호가 올바르지 않습니다."

--- a/resources/i18n/ru.toml
+++ b/resources/i18n/ru.toml
@@ -33,6 +33,11 @@ description = "No access."
 one = "Нет доступа."
 other = "Нет доступа."
 
+[NeedLogin]
+description = "Need login."
+one = "Пожалуйста, войдите в систему."
+other = "Пожалуйста, войдите в систему."
+
 [UsernameOrPasswordError]
 description = "Username or password error."
 one = "Неправильное имя пользователя или пароль."

--- a/resources/i18n/zh_CN.toml
+++ b/resources/i18n/zh_CN.toml
@@ -33,6 +33,11 @@ description = "No access."
 one = "无权限。"
 other = "无权限。"
 
+[NeedLogin]
+description = "Need login."
+one = "请先登录。"
+other = "请先登录。"
+
 [UsernameOrPasswordError]
 description = "Username or password error."
 one = "用户名或密码错误。"

--- a/resources/i18n/zh_TW.toml
+++ b/resources/i18n/zh_TW.toml
@@ -33,6 +33,11 @@ description = "No access."
 one = "無許可權。"
 other = "無許可權。"
 
+[NeedLogin]
+description = "Need login."
+one = "請先登入。"
+other = "請先登入。"
+
 [UsernameOrPasswordError]
 description = "Username or password error."
 one = "使用者名稱或密碼錯誤。"


### PR DESCRIPTION
## feat(i18n): replace hardcoded error messages with translatable strings

This PR replaces hardcoded user-facing error messages with translatable strings using `response.TranslateMsg`.

- Replaced messages like `"请先登录"` and `"无权限"` with `TranslateMsg(...)` calls.
- Added new translation key `"NeedLogin"` to all supported locales:
  - `en`, `zh_CN`, `zh_TW`, `ru`, `fr`, `es`, `ko`
- Improves i18n consistency and supports full localization of system messages.