### PR TITLE
Correct typo in build arg FRONTEND_GIT_REPO

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -42,11 +42,11 @@ RUN if [ "$COUNTRY" = "CN" ] ; then \
     fi && \
     apk update && apk add --no-cache git
 
-ARG FREONTEND_GIT_REPO=https://github.com/lejianwen/rustdesk-api-web.git
+ARG FRONTEND_GIT_REPO=https://github.com/lejianwen/rustdesk-api-web.git
 ARG FRONTEND_GIT_BRANCH=master
 # Clone the frontend repository
 
-RUN git clone -b $FRONTEND_GIT_BRANCH $FREONTEND_GIT_REPO .
+RUN git clone -b $FRONTEND_GIT_BRANCH $FRONTEND_GIT_REPO .
 
 # Install required tools without caching index to minimize image size
 RUN if [ "$COUNTRY" = "CN" ] ; then \

--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -5,7 +5,7 @@ services:
       dockerfile: Dockerfile.dev
       args:
         COUNTRY: CN
-        FREONTEND_GIT_REPO: https://github.com/lejianwen/rustdesk-api-web.git
+        FRONTEND_GIT_REPO: https://github.com/lejianwen/rustdesk-api-web.git
         FRONTEND_GIT_BRANCH: master
     # image: lejianwen/rustdesk-api
     container_name: rustdesk-api


### PR DESCRIPTION
## Correct typo in build argument for frontend repository

### Summary

This PR fixes a typo in the build argument name used for specifying the frontend Git repository.  
The incorrect `FREONTEND_GIT_REPO` has been replaced with the correct `FRONTEND_GIT_REPO` in:

- `Dockerfile.dev`
- `docker-compose-dev.yaml`

### Changes

-  Renamed `FREONTEND_GIT_REPO` → `FRONTEND_GIT_REPO`
-  Ensured consistent use of build args for frontend Git repository and branch