### PR TITLE
feat: better autorenewal

### DIFF
--- a/service/user.go
+++ b/service/user.go
@@ -2,14 +2,14 @@ package service
 
 import (
 	"errors"
-	"github.com/lejianwen/rustdesk-api/v2/model"
-	"github.com/lejianwen/rustdesk-api/v2/utils"
 	"math/rand"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/lejianwen/rustdesk-api/v2/model"
+	"github.com/lejianwen/rustdesk-api/v2/utils"
 	"gorm.io/gorm"
 )
 
@@ -500,8 +500,9 @@ func (us *UserService) RefreshAccessToken(ut *model.UserToken) {
 	ut.ExpiredAt = us.UserTokenExpireTimestamp()
 	DB.Model(ut).Update("expired_at", ut.ExpiredAt)
 }
+
 func (us *UserService) AutoRefreshAccessToken(ut *model.UserToken) {
-	if ut.ExpiredAt-time.Now().Unix() < 86400 {
+	if ut.ExpiredAt-time.Now().Unix() < Config.App.TokenExpire.Milliseconds()/3000 {
 		us.RefreshAccessToken(ut)
 	}
 }


### PR DESCRIPTION
## Background

Currently tokens only get renewed when they are expiring within next 24 hours. This requires users to login at least once per day to keep them loged in -- which can be really inconvenient.

## Changes & Reasons

This PR allow tokens to be renewed when their remaining lifetime is less than a third of the configured value. The threshold `a third` is come from those common certificate autorenewal configuretions -- for example, the default config of `certbot`.