### PR TITLE
Add note in docs about requiring conf and resources directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,12 @@
     #或者使用generate_api.go生成api并运行
     go generate generate_api.go
     ```
+   > 注意：使用 `go run` 或编译后的二进制时，当前目录下必须存在 `conf` 和 `resources`
+   > 目录。如果在其他目录运行，可通过 `-c` 和环境变量
+   > `RUSTDESK_API_GIN_RESOURCES_PATH` 指定绝对路径，例如：
+   > ```bash
+   > RUSTDESK_API_GIN_RESOURCES_PATH=/opt/rustdesk-api/resources ./apimain -c /opt/rustdesk-api/conf/config.yaml
+   > ```
 5. 编译，如果想自己编译,先cd到项目根目录，然后windows下直接运行`build.bat`,linux下运行`build.sh`,编译后会在`release`
    目录下生成对应的可执行文件。直接运行编译后的可执行文件即可。
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -252,10 +252,17 @@ Download the release from [release](https://github.com/lejianwen/rustdesk-api/re
 4. Run:
     ```bash
     # Run directly
-    go run cmd/apimain.go
-    # Or generate and run the API using generate_api.go
-    go generate generate_api.go
-    ```
+   go run cmd/apimain.go
+   # Or generate and run the API using generate_api.go
+   go generate generate_api.go
+   ```
+   > **Note:** When using `go run` or the compiled binary, the `conf` and `resources`
+   > directories must exist relative to the current working directory. If you run
+   > the program from another location, specify absolute paths with `-c` and the
+   > `RUSTDESK_API_GIN_RESOURCES_PATH` environment variable. Example:
+   > ```bash
+   > RUSTDESK_API_GIN_RESOURCES_PATH=/opt/rustdesk-api/resources ./apimain -c /opt/rustdesk-api/conf/config.yaml
+   > ```
 
 5. To compile, change to the project root directory. For Windows, run `build.bat`, and for Linux, run `build.sh`. After
    compiling, the corresponding executables will be generated in the `release` directory. Run the compiled executables


### PR DESCRIPTION
This PR addresses the ambiguity reported in issue #310 by adding a clear note about the requirement for the `conf` and `resources` directories to be present (or explicitly specified) when running the API server. Without this clarification, users running the app from a different working directory could encounter “file not found” errors.