### PR TITLE
[feat] Optimize login workflow

### DIFF
--- a/http/controller/admin/login.go
+++ b/http/controller/admin/login.go
@@ -169,6 +169,8 @@ func (ct *Login) LoginOptions(c *gin.Context) {
 		"ops":          ops,
 		"register":     global.Config.App.Register,
 		"need_captcha": needCaptcha,
+		"disable_pwd": 	global.Config.App.DisablePwdLogin,
+		"auto_oidc":  	global.Config.App.DisablePwdLogin && len(ops) == 1,
 	})
 }
 


### PR DESCRIPTION
## Description
### Feat https://github.com/lejianwen/rustdesk-api-web/pull/21
1. If `disable-pwd-login=true`, the login form will be hidden for the admin web
2. If  `disable-pwd-login=true` and exists only one OIDC, it will auto-login for the web admin web
### Fix
Now, the API-server builds the `RedirectUrl` by the `sechme`+`host` at first, not `Origin`. So if you didn't configure the `api-server`, it can still work for OIDC now.


## Change

1. `/api/admin/login-options`, add two keys `auto_oidc` and `disable_pwd`. It returns 
```json
{
    "auto_oidc": false,
    "disable_pwd": false,
    "need_captcha": false,
    "ops": [
      "xxxx"
    ],
    "register": false
  }
```