### PR TITLE
fix: handle email_verified as JSON string or boolean in OidcUser

### DIFF
--- a/model/oauth.go
+++ b/model/oauth.go
@@ -131,7 +131,8 @@ func (ou *OidcUser) ToOauthUser() *OauthUser {
 	}
 
 	// email_verified may be a JSON boolean or a JSON string depending on the provider.
-	verifiedEmail := strings.Trim(string(ou.VerifiedEmail), `"`) == "true"
+	// When the field is absent or null, ou.VerifiedEmail is nil and defaults to false.
+	verifiedEmail := strings.EqualFold(strings.Trim(string(ou.VerifiedEmail), `"`), "true")
 
 	return &OauthUser{
 		OpenId:        ou.Sub,

--- a/model/oauth.go
+++ b/model/oauth.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"errors"
 	"strconv"
 	"strings"
@@ -112,7 +113,10 @@ type OauthUserBase struct {
 type OidcUser struct {
 	OauthUserBase
 	Sub               string `json:"sub"`
-	VerifiedEmail     bool   `json:"email_verified"`
+	// VerifiedEmail is declared as json.RawMessage because some OIDC providers
+	// (e.g. Amazon Cognito) return email_verified as a JSON string ("true"/"false")
+	// instead of a JSON boolean, which violates the OIDC Core spec (section 5.1).
+	VerifiedEmail     json.RawMessage `json:"email_verified"`
 	PreferredUsername string `json:"preferred_username"`
 	Picture           string `json:"picture"`
 }
@@ -126,12 +130,15 @@ func (ou *OidcUser) ToOauthUser() *OauthUser {
 		username = strings.ToLower(ou.Email)
 	}
 
+	// email_verified may be a JSON boolean or a JSON string depending on the provider.
+	verifiedEmail := strings.Trim(string(ou.VerifiedEmail), `"`) == "true"
+
 	return &OauthUser{
 		OpenId:        ou.Sub,
 		Name:          ou.Name,
 		Username:      username,
 		Email:         ou.Email,
-		VerifiedEmail: ou.VerifiedEmail,
+		VerifiedEmail: verifiedEmail,
 		Picture:       ou.Picture,
 	}
 }

--- a/model/oauth_test.go
+++ b/model/oauth_test.go
@@ -5,38 +5,53 @@ import (
 	"testing"
 )
 
-func TestOidcUser_ToOauthUser_EmailVerified(t *testing.T) {
-	tests := []struct {
-		name          string
-		emailVerified string // raw JSON value
-		want          bool
-	}{
-		{"boolean true", `true`, true},
-		{"boolean false", `false`, false},
-		{"string true", `"true"`, true},
-		{"string false", `"false"`, false},
-		{"string True (case-insensitive)", `"True"`, true},
-		{"string TRUE (case-insensitive)", `"TRUE"`, true},
-		{"null", `null`, false},
-		{"absent (nil)", ``, false},
+func TestOidcUser_ToOauthUser_EmailVerifiedBoolTrue(t *testing.T) {
+	u := &OidcUser{VerifiedEmail: json.RawMessage(`true`)}
+	if !u.ToOauthUser().VerifiedEmail {
+		t.Fatal("expected true for JSON boolean true")
 	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var raw json.RawMessage
-			if tt.emailVerified != "" {
-				raw = json.RawMessage(tt.emailVerified)
-			}
-			u := &OidcUser{
-				OauthUserBase:     OauthUserBase{Name: "Test", Email: "test@example.com"},
-				Sub:               "sub123",
-				VerifiedEmail:     raw,
-				PreferredUsername: "testuser",
-			}
-			got := u.ToOauthUser()
-			if got.VerifiedEmail != tt.want {
-				t.Errorf("VerifiedEmail = %v, want %v (input: %s)", got.VerifiedEmail, tt.want, tt.emailVerified)
-			}
-		})
+func TestOidcUser_ToOauthUser_EmailVerifiedBoolFalse(t *testing.T) {
+	u := &OidcUser{VerifiedEmail: json.RawMessage(`false`)}
+	if u.ToOauthUser().VerifiedEmail {
+		t.Fatal("expected false for JSON boolean false")
+	}
+}
+
+func TestOidcUser_ToOauthUser_EmailVerifiedStringTrue(t *testing.T) {
+	u := &OidcUser{VerifiedEmail: json.RawMessage(`"true"`)}
+	if !u.ToOauthUser().VerifiedEmail {
+		t.Fatal("expected true for JSON string \"true\"")
+	}
+}
+
+func TestOidcUser_ToOauthUser_EmailVerifiedStringFalse(t *testing.T) {
+	u := &OidcUser{VerifiedEmail: json.RawMessage(`"false"`)}
+	if u.ToOauthUser().VerifiedEmail {
+		t.Fatal("expected false for JSON string \"false\"")
+	}
+}
+
+func TestOidcUser_ToOauthUser_EmailVerifiedStringCaseInsensitive(t *testing.T) {
+	for _, s := range []string{`"True"`, `"TRUE"`} {
+		u := &OidcUser{VerifiedEmail: json.RawMessage(s)}
+		if !u.ToOauthUser().VerifiedEmail {
+			t.Fatalf("expected true for %s", s)
+		}
+	}
+}
+
+func TestOidcUser_ToOauthUser_EmailVerifiedNull(t *testing.T) {
+	u := &OidcUser{VerifiedEmail: json.RawMessage(`null`)}
+	if u.ToOauthUser().VerifiedEmail {
+		t.Fatal("expected false for JSON null")
+	}
+}
+
+func TestOidcUser_ToOauthUser_EmailVerifiedAbsent(t *testing.T) {
+	u := &OidcUser{}
+	if u.ToOauthUser().VerifiedEmail {
+		t.Fatal("expected false when email_verified field is absent")
 	}
 }

--- a/model/oauth_test.go
+++ b/model/oauth_test.go
@@ -1,0 +1,42 @@
+package model
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestOidcUser_ToOauthUser_EmailVerified(t *testing.T) {
+	tests := []struct {
+		name          string
+		emailVerified string // raw JSON value
+		want          bool
+	}{
+		{"boolean true", `true`, true},
+		{"boolean false", `false`, false},
+		{"string true", `"true"`, true},
+		{"string false", `"false"`, false},
+		{"string True (case-insensitive)", `"True"`, true},
+		{"string TRUE (case-insensitive)", `"TRUE"`, true},
+		{"null", `null`, false},
+		{"absent (nil)", ``, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var raw json.RawMessage
+			if tt.emailVerified != "" {
+				raw = json.RawMessage(tt.emailVerified)
+			}
+			u := &OidcUser{
+				OauthUserBase:     OauthUserBase{Name: "Test", Email: "test@example.com"},
+				Sub:               "sub123",
+				VerifiedEmail:     raw,
+				PreferredUsername: "testuser",
+			}
+			got := u.ToOauthUser()
+			if got.VerifiedEmail != tt.want {
+				t.Errorf("VerifiedEmail = %v, want %v (input: %s)", got.VerifiedEmail, tt.want, tt.emailVerified)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Some OIDC providers (e.g. Amazon Cognito) return `email_verified` as a JSON string (`"true"`/`"false"`) instead of a JSON boolean, which violates [OIDC Core spec section 5.1](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims).

This caused the following error at login:

```
failed decoding user info: json: cannot unmarshal string into Go struct field OidcUser.email_verified of type bool
```

## Fix

Change `OidcUser.VerifiedEmail` from `bool` to `json.RawMessage`, which accepts any JSON value without type errors. Then normalize both representations using `strings.EqualFold` + `strings.Trim` to handle:

- JSON boolean: `true` / `false`
- JSON string: `"true"` / `"false"` / `"True"` / `"TRUE"` (case-insensitive)
- `null` or absent field → defaults to `false`

## Tests

Added `model/oauth_test.go` covering all the above cases.